### PR TITLE
Hotfix caja

### DIFF
--- a/scripts/HotFixCaja.sql
+++ b/scripts/HotFixCaja.sql
@@ -1,0 +1,3 @@
+ALTER TABLE caja CHANGE COLUMN saldoInicial saldoApertura decimal(25,15) NOT NULL;
+ALTER TABLE caja DROP COLUMN observacion;
+ALTER TABLE caja DROP nroCaja;

--- a/src/main/java/sic/controller/CajaController.java
+++ b/src/main/java/sic/controller/CajaController.java
@@ -14,10 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
-import sic.modelo.BusquedaCajaCriteria;
-import sic.modelo.Caja;
-import sic.modelo.MovimientoCaja;
-import sic.modelo.Usuario;
+import sic.modelo.*;
 import sic.service.ICajaService;
 import sic.service.IEmpresaService;
 import sic.service.IFormaDePagoService;
@@ -54,7 +51,7 @@ public class CajaController {
         return cajaService.getCajaPorId(idCaja);
     }
 
-    @PostMapping("/cajas/empresas/{idEmpresa}/usuarios/{idUsuario}/abrir")
+    @PostMapping("/cajas/apertura/empresas/{idEmpresa}/usuarios/{idUsuario}")
     @ResponseStatus(HttpStatus.CREATED)
     public Caja abrirCaja(@PathVariable long idEmpresa ,
                           @PathVariable long idUsuario,
@@ -99,19 +96,11 @@ public class CajaController {
             fechaHasta.setTimeInMillis(hasta);
         }
         Usuario usuarioApertura = new Usuario();
-        if(idUsuarioApertura != null) {
-            usuarioApertura = usuarioService.getUsuarioPorId(idUsuarioApertura);
-        }
+        if (idUsuarioApertura != null) usuarioApertura = usuarioService.getUsuarioPorId(idUsuarioApertura);
         Usuario usuarioCierre = new Usuario();
-        if(idUsuarioCierre != null) {
-            usuarioCierre = usuarioService.getUsuarioPorId(idUsuarioCierre);
-        }
-        if (tamanio == null || tamanio <= 0) {
-            tamanio = TAMANIO_PAGINA_DEFAULT;
-        }
-        if (pagina == null || pagina < 0) {
-            pagina = 0;
-        }
+        if (idUsuarioCierre != null) usuarioCierre = usuarioService.getUsuarioPorId(idUsuarioCierre);
+        if (tamanio == null || tamanio <= 0) tamanio = TAMANIO_PAGINA_DEFAULT;
+        if (pagina == null || pagina < 0) pagina = 0;
         Pageable pageable = new PageRequest(pagina, tamanio, new Sort(Sort.Direction.DESC, "fechaApertura"));
         BusquedaCajaCriteria criteria = BusquedaCajaCriteria.builder()
                                         .buscaPorFecha((desde != null) && (hasta != null))

--- a/src/main/java/sic/controller/CajaController.java
+++ b/src/main/java/sic/controller/CajaController.java
@@ -13,17 +13,11 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
-import sic.modelo.*;
+import org.springframework.web.bind.annotation.*;
+import sic.modelo.BusquedaCajaCriteria;
+import sic.modelo.Caja;
+import sic.modelo.MovimientoCaja;
+import sic.modelo.Usuario;
 import sic.service.ICajaService;
 import sic.service.IEmpresaService;
 import sic.service.IFormaDePagoService;
@@ -149,10 +143,16 @@ public class CajaController {
                 Date.from(desde.atZone(ZoneId.systemDefault()).toInstant()), Date.from(hasta.atZone(ZoneId.systemDefault()).toInstant()));
     }
 
-    @GetMapping("/cajas/{idCaja}/total-afecta-caja")
+    @GetMapping("/cajas/{idCaja}/saldo-afecta-caja")
     @ResponseStatus(HttpStatus.OK)
-    public BigDecimal getTotalQueAfectaCaja(@PathVariable long idCaja) {
-        return cajaService.getTotalQueAfectaCaja(cajaService.getCajaPorId(idCaja));
+    public BigDecimal getSaldoQueAfectaCaja(@PathVariable long idCaja) {
+        return cajaService.getSaldoQueAfectaCaja(cajaService.getCajaPorId(idCaja));
+    }
+
+    @GetMapping("/cajas/{idCaja}/saldo-sistema")
+    @ResponseStatus(HttpStatus.OK)
+    public BigDecimal getSaldoSistema(@PathVariable long idCaja) {
+        return cajaService.getSaldoSistema(cajaService.getCajaPorId(idCaja));
     }
 
     @GetMapping("/cajas/empresas/{idEmpresa}/estado-ultima-caja")

--- a/src/main/java/sic/controller/CajaController.java
+++ b/src/main/java/sic/controller/CajaController.java
@@ -55,15 +55,8 @@ public class CajaController {
     @ResponseStatus(HttpStatus.CREATED)
     public Caja abrirCaja(@PathVariable long idEmpresa ,
                           @PathVariable long idUsuario,
-                          @RequestParam String observacion,
                           @RequestParam BigDecimal saldoApertura) {
-        return cajaService.abrirCaja(empresaService.getEmpresaPorId(idEmpresa), usuarioService.getUsuarioPorId(idUsuario), observacion, saldoApertura);
-    }
-
-    @PutMapping("/cajas")
-    @ResponseStatus(HttpStatus.OK)
-    public void actualizar(@RequestBody Caja caja) {
-        cajaService.actualizar(caja);        
+        return cajaService.abrirCaja(empresaService.getEmpresaPorId(idEmpresa), usuarioService.getUsuarioPorId(idUsuario), saldoApertura);
     }
     
     @DeleteMapping("/cajas/{idCaja}")
@@ -123,16 +116,12 @@ public class CajaController {
                                                      @RequestParam(value = "idFormaDePago") long idFormaDePago) {
         Caja caja = cajaService.getCajaPorId(idCaja);
         LocalDateTime desde = caja.getFechaApertura().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
-        LocalDateTime hasta = caja.getFechaApertura().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
-        if (caja.getFechaCierre() == null) {
-            hasta = hasta.withHour(23);
-            hasta = hasta.withMinute(59);
-            hasta = hasta.withSecond(59);
-        } else {
-            hasta = caja.getFechaCierre().toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime();
+        Date fechaHasta = new Date();
+        if (caja.getFechaCierre() != null) {
+            fechaHasta = caja.getFechaCierre();
         }
         return cajaService.getMovimientosPorFormaDePagoEntreFechas(caja.getEmpresa(), formaDePagoService.getFormasDePagoPorId(idFormaDePago),
-                Date.from(desde.atZone(ZoneId.systemDefault()).toInstant()), Date.from(hasta.atZone(ZoneId.systemDefault()).toInstant()));
+                caja.getFechaApertura(), fechaHasta);
     }
 
     @GetMapping("/cajas/{idCaja}/saldo-afecta-caja")

--- a/src/main/java/sic/controller/CajaController.java
+++ b/src/main/java/sic/controller/CajaController.java
@@ -53,17 +53,20 @@ public class CajaController {
     public Caja getCajaPorId(@PathVariable long idCaja) {
         return cajaService.getCajaPorId(idCaja);
     }
-    
+
+    @PostMapping("/cajas/empresas/{idEmpresa}/usuarios/{idUsuario}/abrir")
+    @ResponseStatus(HttpStatus.CREATED)
+    public Caja abrirCaja(@PathVariable long idEmpresa ,
+                          @PathVariable long idUsuario,
+                          @RequestParam String observacion,
+                          @RequestParam BigDecimal saldoApertura) {
+        return cajaService.abrirCaja(empresaService.getEmpresaPorId(idEmpresa), usuarioService.getUsuarioPorId(idUsuario), observacion, saldoApertura);
+    }
+
     @PutMapping("/cajas")
     @ResponseStatus(HttpStatus.OK)
     public void actualizar(@RequestBody Caja caja) {
         cajaService.actualizar(caja);        
-    }
-    
-    @PostMapping("/cajas")
-    @ResponseStatus(HttpStatus.CREATED)
-    public Caja guardar(@RequestBody Caja caja) {
-        return cajaService.guardar(caja);
     }
     
     @DeleteMapping("/cajas/{idCaja}")

--- a/src/main/java/sic/modelo/Caja.java
+++ b/src/main/java/sic/modelo/Caja.java
@@ -34,8 +34,6 @@ public class Caja implements Serializable {
     @GeneratedValue
     private long id_Caja;
 
-    private int nroCaja;
-
     @Column(nullable = false)
     @Temporal(TemporalType.TIMESTAMP)
     private Date fechaApertura;
@@ -56,14 +54,11 @@ public class Caja implements Serializable {
     private Usuario usuarioCierraCaja;
 
     @Column(nullable = false)
-    private String observacion;
-
-    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private EstadoCaja estado;
 
     @Column(precision = 25, scale = 15)
-    private BigDecimal saldoInicial;
+    private BigDecimal saldoApertura;
 
     @Column(precision = 25, scale = 15)
     private BigDecimal saldoSistema;

--- a/src/main/java/sic/repository/CajaRepository.java
+++ b/src/main/java/sic/repository/CajaRepository.java
@@ -6,7 +6,6 @@ import org.springframework.data.querydsl.QueryDslPredicateExecutor;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
 import sic.modelo.Caja;
-import sic.modelo.Empresa;
 
 import java.math.BigDecimal;
 import java.util.Date;
@@ -16,7 +15,8 @@ public interface CajaRepository extends PagingAndSortingRepository<Caja, Long>, 
     @Query("SELECT c FROM Caja c WHERE c.id_Caja = :idCaja AND c.eliminada = false")
     Caja findById(@Param("idCaja") long idCaja);
 
-    Caja findTopByEmpresaAndEliminadaOrderByFechaAperturaDesc(Empresa empresa, boolean eliminada);
+    @Query("SELECT c FROM Caja c WHERE c.empresa.id_Empresa = :idEmpresa AND c.eliminada = false ORDER BY c.id_Caja DESC")
+    Caja findTopByEmpresaAndEliminadaOrderByIdCajaDesc(@Param("idEmpresa") long idEmpresa);
 
     @Query("SELECT c FROM Caja c " +
             "WHERE c.empresa.id_Empresa = :idEmpresa AND c.eliminada = false AND c.estado = sic.modelo.EstadoCaja.ABIERTA " +

--- a/src/main/java/sic/repository/CajaRepository.java
+++ b/src/main/java/sic/repository/CajaRepository.java
@@ -20,9 +20,5 @@ public interface CajaRepository extends PagingAndSortingRepository<Caja, Long>, 
             "WHERE c.empresa.id_Empresa = :idEmpresa AND c.eliminada = false AND c.estado = sic.modelo.EstadoCaja.ABIERTA " +
             "ORDER BY c.id_Caja DESC")
     Caja isUltimaCajaAbierta(@Param("idEmpresa") long idEmpresa);
-
-    @Modifying
-    @Query("UPDATE Caja c SET c.saldoSistema = c.saldoSistema + :monto WHERE c.id_Caja = :idCaja AND c.estado = sic.modelo.EstadoCaja.ABIERTA")
-    int actualizarSaldoSistema(@Param("idCaja") long idCaja, @Param("monto") BigDecimal monto);
       
 }

--- a/src/main/java/sic/repository/CajaRepository.java
+++ b/src/main/java/sic/repository/CajaRepository.java
@@ -26,7 +26,7 @@ public interface CajaRepository extends PagingAndSortingRepository<Caja, Long>, 
     @Query("SELECT c FROM Caja c " +
             "WHERE c.empresa.id_Empresa = :idEmpresa AND c.eliminada = false AND c.estado = sic.modelo.EstadoCaja.CERRADA " +
             "AND :fecha BETWEEN c.fechaApertura AND c.fechaCierre")
-    Caja encontrarCajaCerradaQueContengaFecha(@Param("idEmpresa") long idEmpresa, @Param("fecha") Date fecha);
+    Caja encontrarCajaCerradaQueContengaFechaEntreFechaAperturaYFechaCierre(@Param("idEmpresa") long idEmpresa, @Param("fecha") Date fecha);
 
     @Modifying
     @Query("UPDATE Caja c SET c.saldoSistema = c.saldoSistema + :monto WHERE c.id_Caja = :idCaja AND c.estado = sic.modelo.EstadoCaja.CERRADA")

--- a/src/main/java/sic/repository/CajaRepository.java
+++ b/src/main/java/sic/repository/CajaRepository.java
@@ -1,6 +1,5 @@
 package sic.repository;
 
-import java.math.BigDecimal;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.querydsl.QueryDslPredicateExecutor;
@@ -8,6 +7,9 @@ import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
 import sic.modelo.Caja;
 import sic.modelo.Empresa;
+
+import java.math.BigDecimal;
+import java.util.Date;
 
 public interface CajaRepository extends PagingAndSortingRepository<Caja, Long>, QueryDslPredicateExecutor<Caja>, CajaRepositoryCustom {
 
@@ -20,5 +22,14 @@ public interface CajaRepository extends PagingAndSortingRepository<Caja, Long>, 
             "WHERE c.empresa.id_Empresa = :idEmpresa AND c.eliminada = false AND c.estado = sic.modelo.EstadoCaja.ABIERTA " +
             "ORDER BY c.id_Caja DESC")
     Caja isUltimaCajaAbierta(@Param("idEmpresa") long idEmpresa);
-      
+
+    @Query("SELECT c FROM Caja c " +
+            "WHERE c.empresa.id_Empresa = :idEmpresa AND c.eliminada = false AND c.estado = sic.modelo.EstadoCaja.CERRADA " +
+            "AND :fecha BETWEEN c.fechaApertura AND c.fechaCierre")
+    Caja encontrarCajaCerradaQueContengaFecha(@Param("idEmpresa") long idEmpresa, @Param("fecha") Date fecha);
+
+    @Modifying
+    @Query("UPDATE Caja c SET c.saldoSistema = c.saldoSistema + :monto WHERE c.id_Caja = :idCaja AND c.estado = sic.modelo.EstadoCaja.CERRADA")
+    int actualizarSaldoSistema(@Param("idCaja") long idCaja, @Param("monto") BigDecimal monto);
+
 }

--- a/src/main/java/sic/repository/GastoRepository.java
+++ b/src/main/java/sic/repository/GastoRepository.java
@@ -35,6 +35,12 @@ public interface GastoRepository extends PagingAndSortingRepository<Gasto, Long>
             "WHERE g.empresa.id_Empresa = :idEmpresa " +
             "AND g.formaDePago.afectaCaja = true " +
             "AND g.fecha BETWEEN :desde AND :hasta AND g.eliminado = false")
+    BigDecimal getTotalGastosQueAfectanCajaEntreFechas(@Param("idEmpresa") long idEmpresa,
+                                                       @Param("desde") Date desde, @Param("hasta") Date hasta);
+
+    @Query("SELECT SUM(g.monto) FROM Gasto g " +
+            "WHERE g.empresa.id_Empresa = :idEmpresa " +
+            "AND g.fecha BETWEEN :desde AND :hasta AND g.eliminado = false")
     BigDecimal getTotalGastosEntreFechas(@Param("idEmpresa") long idEmpresa,
                                          @Param("desde") Date desde, @Param("hasta") Date hasta);
 

--- a/src/main/java/sic/repository/ReciboRepository.java
+++ b/src/main/java/sic/repository/ReciboRepository.java
@@ -46,7 +46,7 @@ public interface ReciboRepository extends PagingAndSortingRepository<Recibo, Lon
             "AND (r.proveedor is null) " +
             "AND r.formaDePago.afectaCaja = true " +
             "AND r.fecha BETWEEN :desde AND :hasta AND r.eliminado = false")
-    BigDecimal getTotalRecibosClientesEntreFechasPorFormaDePago(@Param("idEmpresa") long idEmpresa,
+    BigDecimal getTotalRecibosClientesQueAfectanCajaEntreFechas(@Param("idEmpresa") long idEmpresa,
                                                                 @Param("desde") Date desde, @Param("hasta") Date hasta);
 
     @Query("SELECT SUM(r.monto) FROM Recibo r " +
@@ -54,6 +54,20 @@ public interface ReciboRepository extends PagingAndSortingRepository<Recibo, Lon
             "AND (r.cliente is null) " +
             "AND r.formaDePago.afectaCaja = true " +
             "AND r.fecha BETWEEN :desde AND :hasta AND r.eliminado = false")
-    BigDecimal getTotalRecibosProveedoresEntreFechasPorFormaDePago(@Param("idEmpresa") long idEmpresa,
+    BigDecimal getTotalRecibosProveedoresQueAfectanCajaEntreFechas(@Param("idEmpresa") long idEmpresa,
+                                                                   @Param("desde") Date desde, @Param("hasta") Date hasta);
+
+    @Query("SELECT SUM(r.monto) FROM Recibo r " +
+            "WHERE r.empresa.id_Empresa = :idEmpresa " +
+            "AND (r.proveedor is null) " +
+            "AND r.fecha BETWEEN :desde AND :hasta AND r.eliminado = false")
+    BigDecimal getTotalRecibosClientesEntreFechas(@Param("idEmpresa") long idEmpresa,
+                                                                @Param("desde") Date desde, @Param("hasta") Date hasta);
+
+    @Query("SELECT SUM(r.monto) FROM Recibo r " +
+            "WHERE r.empresa.id_Empresa = :idEmpresa " +
+            "AND (r.cliente is null) " +
+            "AND r.fecha BETWEEN :desde AND :hasta AND r.eliminado = false")
+    BigDecimal getTotalRecibosProveedoresEntreFechas(@Param("idEmpresa") long idEmpresa,
                                                                    @Param("desde") Date desde, @Param("hasta") Date hasta);
 }

--- a/src/main/java/sic/repository/ReciboRepository.java
+++ b/src/main/java/sic/repository/ReciboRepository.java
@@ -62,12 +62,12 @@ public interface ReciboRepository extends PagingAndSortingRepository<Recibo, Lon
             "AND (r.proveedor is null) " +
             "AND r.fecha BETWEEN :desde AND :hasta AND r.eliminado = false")
     BigDecimal getTotalRecibosClientesEntreFechas(@Param("idEmpresa") long idEmpresa,
-                                                                @Param("desde") Date desde, @Param("hasta") Date hasta);
+                                                  @Param("desde") Date desde, @Param("hasta") Date hasta);
 
     @Query("SELECT SUM(r.monto) FROM Recibo r " +
             "WHERE r.empresa.id_Empresa = :idEmpresa " +
             "AND (r.cliente is null) " +
             "AND r.fecha BETWEEN :desde AND :hasta AND r.eliminado = false")
     BigDecimal getTotalRecibosProveedoresEntreFechas(@Param("idEmpresa") long idEmpresa,
-                                                                   @Param("desde") Date desde, @Param("hasta") Date hasta);
+                                                     @Param("desde") Date desde, @Param("hasta") Date hasta);
 }

--- a/src/main/java/sic/service/ICajaService.java
+++ b/src/main/java/sic/service/ICajaService.java
@@ -22,7 +22,7 @@ public interface ICajaService {
 
     Caja getUltimaCaja(long id_Empresa);
 
-    Caja abrirCaja(Empresa empresa, Usuario usuarioApertura, String observacion, BigDecimal saldoApertura);
+    Caja abrirCaja(Empresa empresa, Usuario usuarioApertura, BigDecimal saldoApertura);
 
     void validarCaja(Caja caja);
     
@@ -42,7 +42,7 @@ public interface ICajaService {
 
     void reabrirCaja(long idCaja, BigDecimal saldoInicial, long idUsuario);
 
-    Caja encontrarCajaCerradaQueContengaFecha(long idEmpresa, Date fecha);
+    Caja encontrarCajaCerradaQueContengaFechaEntreFechaAperturaYFechaCierre(long idEmpresa, Date fecha);
 
     int actualizarSaldoSistema(Caja caja, BigDecimal monto);
 

--- a/src/main/java/sic/service/ICajaService.java
+++ b/src/main/java/sic/service/ICajaService.java
@@ -24,7 +24,7 @@ public interface ICajaService {
 
     int getUltimoNumeroDeCaja(long id_Empresa);
 
-    Caja guardar(Caja caja);
+    Caja abrirCaja(Empresa empresa, Usuario usuarioApertura, String observacion, BigDecimal saldoApertura);
 
     void validarCaja(Caja caja);
     

--- a/src/main/java/sic/service/ICajaService.java
+++ b/src/main/java/sic/service/ICajaService.java
@@ -30,7 +30,9 @@ public interface ICajaService {
     
     Caja cerrarCaja(long idCaja, BigDecimal monto, Long idUsuario, boolean scheduling);
     
-    BigDecimal getTotalQueAfectaCaja(Caja caja);
+    BigDecimal getSaldoQueAfectaCaja(Caja caja);
+
+    BigDecimal getSaldoSistema(Caja caja);
 
     boolean isUltimaCajaAbierta(long idEmpresa);
     
@@ -40,9 +42,6 @@ public interface ICajaService {
     
     List<MovimientoCaja> getMovimientosPorFormaDePagoEntreFechas(Empresa empresa, FormaDePago formaDePago, Date desde, Date hasta);
 
-    void actualizarSaldoSistema(Recibo recibo, TipoDeOperacion tipoDeOperacion);
-
-    void actualizarSaldoSistema(Gasto gasto, TipoDeOperacion tipoDeOperacion);
-
     void reabrirCaja(long idCaja, BigDecimal saldoInicial, long idUsuario);
+
 }

--- a/src/main/java/sic/service/ICajaService.java
+++ b/src/main/java/sic/service/ICajaService.java
@@ -22,8 +22,6 @@ public interface ICajaService {
 
     Caja getUltimaCaja(long id_Empresa);
 
-    int getUltimoNumeroDeCaja(long id_Empresa);
-
     Caja abrirCaja(Empresa empresa, Usuario usuarioApertura, String observacion, BigDecimal saldoApertura);
 
     void validarCaja(Caja caja);
@@ -43,5 +41,9 @@ public interface ICajaService {
     List<MovimientoCaja> getMovimientosPorFormaDePagoEntreFechas(Empresa empresa, FormaDePago formaDePago, Date desde, Date hasta);
 
     void reabrirCaja(long idCaja, BigDecimal saldoInicial, long idUsuario);
+
+    Caja encontrarCajaCerradaQueContengaFecha(long idEmpresa, Date fecha);
+
+    int actualizarSaldoSistema(Caja caja, BigDecimal monto);
 
 }

--- a/src/main/java/sic/service/IGastoService.java
+++ b/src/main/java/sic/service/IGastoService.java
@@ -25,6 +25,8 @@ public interface IGastoService {
 
     BigDecimal getTotalGastosEntreFechasYFormaDePago(long idEmpresa, long idFormaDePago, Date desde, Date hasta);
 
+    BigDecimal getTotalGastosQueAfectanCajaEntreFechas(long idEmpresa, Date desde, Date hasta);
+
     BigDecimal getTotalGastosEntreFechas(long idEmpresa, Date desde, Date hasta);
 
 }

--- a/src/main/java/sic/service/IReciboService.java
+++ b/src/main/java/sic/service/IReciboService.java
@@ -29,6 +29,10 @@ public interface IReciboService {
 
     List<Recibo> getRecibosEntreFechasPorFormaDePago(Date desde, Date hasta, FormaDePago formaDePago, Empresa empresa);
 
+    BigDecimal getTotalRecibosClientesQueAfectanCajaEntreFechas(long idEmpresa, Date desde, Date hasta);
+
+    BigDecimal getTotalRecibosProveedoresQueAfectanCajaEntreFechas(long idEmpresa, Date desde, Date hasta);
+
     BigDecimal getTotalRecibosClientesEntreFechas(long idEmpresa, Date desde, Date hasta);
 
     BigDecimal getTotalRecibosProveedoresEntreFechas(long idEmpresa, Date desde, Date hasta);

--- a/src/main/java/sic/service/impl/CajaServiceImpl.java
+++ b/src/main/java/sic/service/impl/CajaServiceImpl.java
@@ -106,14 +106,16 @@ public class CajaServiceImpl implements ICajaService {
 
     @Override
     @Transactional
-    public Caja guardar(Caja caja) {
+    public Caja abrirCaja(Empresa empresa, Usuario usuarioApertura, String observacion, BigDecimal saldoApertura) {
+        Caja caja = new Caja();
+        caja.setEstado(EstadoCaja.ABIERTA);
+        caja.setObservacion("Apertura de Caja");
+        caja.setEmpresa(empresa);
+        caja.setSaldoInicial(saldoApertura);
+        caja.setUsuarioAbreCaja(usuarioApertura);
         caja.setFechaApertura(new Date());
-        caja.setSaldoSistema(null);
         this.validarCaja(caja);
-        caja.setNroCaja(this.getUltimoNumeroDeCaja(caja.getEmpresa().getId_Empresa()) + 1);
-        caja = cajaRepository.save(caja);
-        LOGGER.warn("La Caja " + caja + " se guardó correctamente.");
-        return caja;
+        return cajaRepository.save(caja);
     }
 
     @Override

--- a/src/main/java/sic/service/impl/CajaServiceImpl.java
+++ b/src/main/java/sic/service/impl/CajaServiceImpl.java
@@ -137,7 +137,7 @@ public class CajaServiceImpl implements ICajaService {
 
     @Override
     public Caja getUltimaCaja(long id_Empresa) {
-        return cajaRepository.findTopByEmpresaAndEliminadaOrderByFechaAperturaDesc(empresaService.getEmpresaPorId(id_Empresa), false);
+        return cajaRepository.findTopByEmpresaAndEliminadaOrderByIdCajaDesc(id_Empresa);
     }
 
     @Override
@@ -346,7 +346,7 @@ public class CajaServiceImpl implements ICajaService {
         Usuario usuario = usuarioService.getUsuarioPorId(idUsuario);
         if (usuario.getRoles().contains(Rol.ADMINISTRADOR)) {
             Caja caja = getCajaPorId(idCaja);
-            if (caja.getFechaApertura().toInstant().atZone(ZoneId.systemDefault()).toLocalDate().isEqual(LocalDate.now())) {
+            if (caja.getId_Caja() ==  this.getUltimaCaja(caja.getEmpresa().getId_Empresa()).getId_Caja()) {
                 caja.setSaldoSistema(null);
                 caja.setSaldoApertura(saldoAperturaNuevo);
                 caja.setSaldoReal(null);

--- a/src/main/java/sic/service/impl/CajaServiceImpl.java
+++ b/src/main/java/sic/service/impl/CajaServiceImpl.java
@@ -109,9 +109,8 @@ public class CajaServiceImpl implements ICajaService {
     public Caja abrirCaja(Empresa empresa, Usuario usuarioApertura, String observacion, BigDecimal saldoApertura) {
         Caja caja = new Caja();
         caja.setEstado(EstadoCaja.ABIERTA);
-        caja.setObservacion("Apertura de Caja");
         caja.setEmpresa(empresa);
-        caja.setSaldoInicial(saldoApertura);
+        caja.setSaldoApertura(saldoApertura);
         caja.setUsuarioAbreCaja(usuarioApertura);
         caja.setFechaApertura(new Date());
         this.validarCaja(caja);
@@ -149,16 +148,6 @@ public class CajaServiceImpl implements ICajaService {
                     .getString("mensaje_caja_no_existente"));
         }
         return caja;
-    }
-
-    @Override
-    public int getUltimoNumeroDeCaja(long idEmpresa) {
-        Caja caja = this.getUltimaCaja(idEmpresa);
-        if (caja == null) {
-            return 0;
-        } else {
-            return caja.getNroCaja();
-        }
     }
 
     @Override
@@ -281,7 +270,7 @@ public class CajaServiceImpl implements ICajaService {
                 caja.getFechaApertura(), Date.from(ldt.atZone(ZoneId.systemDefault()).toInstant()));
         BigDecimal totalGastos = gastoService.getTotalGastosQueAfectanCajaEntreFechas(caja.getEmpresa().getId_Empresa(),
                 caja.getFechaApertura(), Date.from(ldt.atZone(ZoneId.systemDefault()).toInstant()));
-        return caja.getSaldoInicial().add(totalRecibosCliente).subtract(totalRecibosProveedor).subtract(totalGastos);
+        return caja.getSaldoApertura().add(totalRecibosCliente).subtract(totalRecibosProveedor).subtract(totalGastos);
     }
 
     @Override
@@ -301,7 +290,7 @@ public class CajaServiceImpl implements ICajaService {
                     caja.getFechaApertura(), Date.from(ldt.atZone(ZoneId.systemDefault()).toInstant()));
             BigDecimal totalGastos = gastoService.getTotalGastosEntreFechas(caja.getEmpresa().getId_Empresa(),
                     caja.getFechaApertura(), Date.from(ldt.atZone(ZoneId.systemDefault()).toInstant()));
-            return caja.getSaldoInicial().add(totalRecibosCliente).subtract(totalRecibosProveedor).subtract(totalGastos);
+            return caja.getSaldoApertura().add(totalRecibosCliente).subtract(totalRecibosProveedor).subtract(totalGastos);
         } else {
             return caja.getSaldoSistema();
         }
@@ -371,7 +360,7 @@ public class CajaServiceImpl implements ICajaService {
             Caja caja = getCajaPorId(idCaja);
             if (caja.getFechaApertura().toInstant().atZone(ZoneId.systemDefault()).toLocalDate().isEqual(LocalDate.now())) {
                 caja.setSaldoSistema(null);
-                caja.setSaldoInicial(saldoAperturaNuevo);
+                caja.setSaldoApertura(saldoAperturaNuevo);
                 caja.setSaldoReal(BigDecimal.ZERO);
                 caja.setEstado(EstadoCaja.ABIERTA);
                 caja.setUsuarioCierraCaja(null);
@@ -387,4 +376,14 @@ public class CajaServiceImpl implements ICajaService {
         }
     }
 
+    @Override
+    public Caja encontrarCajaCerradaQueContengaFecha(long idEmpresa, Date fecha) {
+        return cajaRepository.encontrarCajaCerradaQueContengaFecha(idEmpresa, fecha);
+    }
+
+    @Override
+    @Transactional
+    public int actualizarSaldoSistema(Caja caja, BigDecimal monto) {
+        return cajaRepository.actualizarSaldoSistema(caja.getId_Caja(), monto);
+    }
 }

--- a/src/main/java/sic/service/impl/EmpresaServiceImpl.java
+++ b/src/main/java/sic/service/impl/EmpresaServiceImpl.java
@@ -29,18 +29,15 @@ public class EmpresaServiceImpl implements IEmpresaService {
     private final EmpresaRepository empresaRepository;
     private final IConfiguracionDelSistemaService configuracionDelSistemaService;
     private final IAmazonService amazonService;
-    private final IUsuarioService usuarioService;
     private final Logger LOGGER = LoggerFactory.getLogger(this.getClass());
     
     @Autowired
     public EmpresaServiceImpl(EmpresaRepository empresaRepository,
             IConfiguracionDelSistemaService configuracionDelSistemaService,
-            IUsuarioService usuarioService,
             IAmazonService amazonService) {
 
         this.empresaRepository = empresaRepository;
         this.configuracionDelSistemaService = configuracionDelSistemaService;
-        this.usuarioService = usuarioService;
         this.amazonService = amazonService;
     }
     

--- a/src/main/java/sic/service/impl/GastoServiceImpl.java
+++ b/src/main/java/sic/service/impl/GastoServiceImpl.java
@@ -114,7 +114,7 @@ public class GastoServiceImpl implements IGastoService {
     @Transactional
     public void eliminar(long idGasto) {
         Gasto gastoParaEliminar = this.getGastoPorId(idGasto);
-        if(this.cajaService.getUltimaCaja(gastoParaEliminar.getEmpresa().getId_Empresa()).getEstado().equals(EstadoCaja.CERRADA)){
+        if (this.cajaService.getUltimaCaja(gastoParaEliminar.getEmpresa().getId_Empresa()).getEstado().equals(EstadoCaja.CERRADA)) {
             throw new BusinessServiceException(ResourceBundle.getBundle("Mensajes")
                     .getString("mensaje_gasto_caja_cerrada"));
         }

--- a/src/main/java/sic/service/impl/GastoServiceImpl.java
+++ b/src/main/java/sic/service/impl/GastoServiceImpl.java
@@ -95,7 +95,6 @@ public class GastoServiceImpl implements IGastoService {
         this.validarGasto(gasto);
         gasto.setNroGasto(this.getUltimoNumeroDeGasto(gasto.getEmpresa().getId_Empresa()) + 1);
         gasto = gastoRepository.save(gasto);
-        this.cajaService.actualizarSaldoSistema(gasto, TipoDeOperacion.ALTA);
         LOGGER.warn("El Gasto " + gasto + " se guardó correctamente." );
         return gasto;
     }
@@ -121,7 +120,6 @@ public class GastoServiceImpl implements IGastoService {
         }
         gastoParaEliminar.setEliminado(true);
         gastoRepository.save(gastoParaEliminar);
-        this.cajaService.actualizarSaldoSistema(gastoParaEliminar, TipoDeOperacion.ELIMINACION);
     }
     
     @Override
@@ -132,6 +130,12 @@ public class GastoServiceImpl implements IGastoService {
     @Override
     public BigDecimal getTotalGastosEntreFechasYFormaDePago(long idEmpresa, long idFormaDePago, Date desde, Date hasta) {
         BigDecimal total = gastoRepository.getTotalGastosEntreFechasPorFormaDePago(idEmpresa, idFormaDePago, desde, hasta);
+        return (total == null) ? BigDecimal.ZERO : total;
+    }
+
+    @Override
+    public BigDecimal getTotalGastosQueAfectanCajaEntreFechas(long idEmpresa, Date desde, Date hasta) {
+        BigDecimal total = gastoRepository.getTotalGastosQueAfectanCajaEntreFechas(idEmpresa, desde, hasta);
         return (total == null) ? BigDecimal.ZERO : total;
     }
 

--- a/src/main/java/sic/service/impl/ReciboServiceImpl.java
+++ b/src/main/java/sic/service/impl/ReciboServiceImpl.java
@@ -70,7 +70,6 @@ public class ReciboServiceImpl implements IReciboService {
         this.validarRecibo(recibo);
         recibo = reciboRepository.save(recibo);
         this.cuentaCorrienteService.asentarEnCuentaCorriente(recibo, TipoDeOperacion.ALTA);
-        this.cajaService.actualizarSaldoSistema(recibo, TipoDeOperacion.ALTA);
         LOGGER.warn("El Recibo " + recibo + " se guardó correctamente.");
         return recibo;
     }
@@ -154,9 +153,8 @@ public class ReciboServiceImpl implements IReciboService {
     @Transactional
     public void eliminar(long idRecibo) {
         Recibo r = reciboRepository.findById(idRecibo);
-        if (notaService.existeNotaDebitoPorRecibo(r) == false) {
+        if (!notaService.existeNotaDebitoPorRecibo(r)) {
             r.setEliminado(true);
-            this.cajaService.actualizarSaldoSistema(r, TipoDeOperacion.ELIMINACION);
             this.cuentaCorrienteService.asentarEnCuentaCorriente(r, TipoDeOperacion.ELIMINACION);
             reciboRepository.save(r);
             LOGGER.warn("El Recibo " + r + " se eliminó correctamente.");
@@ -213,15 +211,28 @@ public class ReciboServiceImpl implements IReciboService {
     }
 
     @Override
+    public BigDecimal getTotalRecibosClientesQueAfectanCajaEntreFechas(long idEmpresa, Date desde, Date hasta) {
+        BigDecimal total = reciboRepository.getTotalRecibosClientesQueAfectanCajaEntreFechas(idEmpresa, desde, hasta);
+        return (total == null) ? BigDecimal.ZERO : total;
+    }
+
+    @Override
+    public BigDecimal getTotalRecibosProveedoresQueAfectanCajaEntreFechas(long idEmpresa, Date desde, Date hasta) {
+        BigDecimal total = reciboRepository.getTotalRecibosProveedoresQueAfectanCajaEntreFechas(idEmpresa, desde, hasta);
+        return (total == null) ? BigDecimal.ZERO : total;
+    }
+
+    @Override
     public BigDecimal getTotalRecibosClientesEntreFechas(long idEmpresa, Date desde, Date hasta) {
-        BigDecimal total = reciboRepository.getTotalRecibosClientesEntreFechasPorFormaDePago(idEmpresa, desde, hasta);
+        BigDecimal total = reciboRepository.getTotalRecibosClientesEntreFechas(idEmpresa, desde, hasta);
         return (total == null) ? BigDecimal.ZERO : total;
     }
 
     @Override
     public BigDecimal getTotalRecibosProveedoresEntreFechas(long idEmpresa, Date desde, Date hasta) {
-        BigDecimal total = reciboRepository.getTotalRecibosProveedoresEntreFechasPorFormaDePago(idEmpresa, desde, hasta);
+        BigDecimal total = reciboRepository.getTotalRecibosProveedoresEntreFechas(idEmpresa, desde, hasta);
         return (total == null) ? BigDecimal.ZERO : total;
     }
-  
+
+
 }

--- a/src/main/java/sic/service/impl/ReciboServiceImpl.java
+++ b/src/main/java/sic/service/impl/ReciboServiceImpl.java
@@ -161,7 +161,7 @@ public class ReciboServiceImpl implements IReciboService {
     }
 
     private void actualizarCajaPorEliminacionDeRecibo(Recibo recibo) {
-        Caja caja = this.cajaService.encontrarCajaCerradaQueContengaFecha(recibo.getEmpresa().getId_Empresa(), recibo.getFecha());
+        Caja caja = this.cajaService.encontrarCajaCerradaQueContengaFechaEntreFechaAperturaYFechaCierre(recibo.getEmpresa().getId_Empresa(), recibo.getFecha());
         BigDecimal monto = BigDecimal.ZERO;
         if (caja != null && caja.getEstado().equals(EstadoCaja.CERRADA)) {
             if (recibo.getCliente() != null) {

--- a/src/main/resources/Mensajes.properties
+++ b/src/main/resources/Mensajes.properties
@@ -211,7 +211,7 @@ mensaje_caja_anterior_abierta=La caja anterior a\u00fan se encuentra abierta.
 mensaje_fecha_apertura_no_valida=La fecha de apertura de la caja no es v\u00e1lida.
 mensaje_caja_no_existente=La caja no existe.
 mensaje_caja_usuario_no_administrador=Se necesita ser administrador para abrir una caja.
-mensaje_caja_re_apertura_no_valida=La caja no se puede volver a abrir porque pertenece a un día anterior al actual.
+mensaje_caja_re_apertura_no_valida=La caja no se puede volver a abrir porque ya existe una caja posterior.
 mensaje_caja_nro_no_valido=El numero de la caja no corresponde con uno válido.
 
 #Gasto

--- a/src/main/resources/Mensajes.properties
+++ b/src/main/resources/Mensajes.properties
@@ -212,6 +212,7 @@ mensaje_fecha_apertura_no_valida=La fecha de apertura de la caja no es v\u00e1li
 mensaje_caja_no_existente=La caja no existe.
 mensaje_caja_usuario_no_administrador=Se necesita ser administrador para abrir una caja.
 mensaje_caja_re_apertura_no_valida=La caja no se puede volver a abrir porque pertenece a un día anterior al actual.
+mensaje_caja_nro_no_valido=El numero de la caja no corresponde con uno válido.
 
 #Gasto
 mensaje_gasto_fecha_vacia=La fecha se encuentra vac\u00eda.

--- a/src/main/resources/Mensajes.properties
+++ b/src/main/resources/Mensajes.properties
@@ -211,7 +211,7 @@ mensaje_caja_anterior_abierta=La caja anterior a\u00fan se encuentra abierta.
 mensaje_fecha_apertura_no_valida=La fecha de apertura de la caja no es v\u00e1lida.
 mensaje_caja_no_existente=La caja no existe.
 mensaje_caja_usuario_no_administrador=Se necesita ser administrador para abrir una caja.
-mensaje_caja_re_apertura_no_valida=La caja no se puede volver a abrir porque ya existe una caja posterior.
+mensaje_caja_re_apertura_no_valida=La caja no se puede volver a abrir porque ya existe una caja posterior abierta.
 mensaje_caja_nro_no_valido=El numero de la caja no corresponde con uno válido.
 
 #Gasto

--- a/src/test/java/sic/builder/CajaBuilder.java
+++ b/src/test/java/sic/builder/CajaBuilder.java
@@ -10,12 +10,10 @@ import sic.modelo.Usuario;
 public class CajaBuilder {
 
     private long id_Caja = 0L;
-    private int nroCaja = 22;
     private Date fechaApertura = new Date();
     private Date fechaCierre;
     private Usuario usuarioAbreCaja = new UsuarioBuilder().build();
     private Usuario usuarioCierraCaja = new UsuarioBuilder().build();
-    private String observacion = "Caja Default para Test";
     private EstadoCaja estado = EstadoCaja.ABIERTA;
     private BigDecimal saldoInicial = new BigDecimal("400");
     private BigDecimal saldoSistema;
@@ -24,18 +22,13 @@ public class CajaBuilder {
     private Empresa empresa = new EmpresaBuilder().build();
 
     public Caja build() {
-        return new Caja(id_Caja, nroCaja, fechaApertura, fechaCierre, empresa,
-                usuarioAbreCaja, usuarioCierraCaja, observacion, estado,
+        return new Caja(id_Caja, fechaApertura, fechaCierre, empresa,
+                usuarioAbreCaja, usuarioCierraCaja, estado,
                 saldoInicial, saldoSistema, saldoReal, eliminada);
     }
 
     public CajaBuilder withIdCaja(long idCaja) {
         this.id_Caja = idCaja;
-        return this;
-    }
-
-    public CajaBuilder withNroCaja(int nroCaja) {
-        this.nroCaja = nroCaja;
         return this;
     }
 
@@ -56,11 +49,6 @@ public class CajaBuilder {
 
     public CajaBuilder withUsuarioCierraCaja(Usuario usuarioCierraCaja) {
         this.usuarioCierraCaja = usuarioCierraCaja;
-        return this;
-    }
-
-    public CajaBuilder withObservacion(String observacion) {
-        this.observacion = observacion;
         return this;
     }
 


### PR DESCRIPTION
1. Elimina el endpoint para guardar cajas y se reemplaza por uno de apertura. 
2. Modifica la forma de calcular el saldo sistema, se hace siempre que se consulta por la caja y sólo se persiste al cerrar la misma.